### PR TITLE
Restored the 2019 with the original information

### DIFF
--- a/2019/masoli_et_al_2019/masoli_et_al_2019.html
+++ b/2019/masoli_et_al_2019/masoli_et_al_2019.html
@@ -40,7 +40,7 @@
                     </tbody>
                 </table>
             </a>
-            <h5 class="title-style">Parameter tuning differentiates granule cell subtypes enriching transmission properties at the cerebellum input stage</h5>
+            <h5 class="title-style">Parameter tuning differentiates granule cell subtypes enriching the repertoire of retransmission properties at the cerebellum input stage</h5>
         </div>
         <div>
             <p>
@@ -79,23 +79,23 @@
         <div>
             <p>
             <strong>Journal: </strong>
-            <a href="https://www.nature.com" target="_blank">
-                <span class="color_link">Nature</span>
+            <a href="https://www.biorxiv.org/" target="_blank">
+                <span class="color_link">Biorxiv</span>
             </a>
             </p>
             <p>
             <strong>Download Url: </strong>
-            <a href="https://www.nature.com/articles/s42003-020-0953-x" target="_blank">
-                <span class="color_link">https://www.nature.com/articles/s42003-020-0953-x</span>
+            <a href="https://www.biorxiv.org/content/10.1101/638247v1" target="_blank">
+                <span class="color_link">https://www.biorxiv.org/content/10.1101/638247v1</span>
             </a>
             </p>
             <p>
-            <strong>Citation: </strong> Masoli S.*, Tognolina M.*, Laforenza U., Moccia F., D’Angelo E. Parameter tuning differentiates granule cell subtypes enriching transmission properties at the cerebellum input stage. Nature Communications Biology 2020.
+            <strong>Citation: </strong> Masoli S.*, Tognolina M.*, Laforenza U., Moccia F., D’Angelo E. Parameter tuning differentiates granule cell subtypes enriching the repertoire of retransmission properties at the cerebellum input stage. Biorxiv 2019.
             </p>
             <p>
             <strong>DOI: </strong>
-            <a href="https://doi.org/10.1038/s42003-020-0953-x" target="_blank">
-                <span class="color_link">https://doi.org/10.1038/s42003-020-0953-x</span>
+            <a href="https://doi.org/10.1101/638247 " target="_blank">
+                <span class="color_link">https://doi.org/10.1101/638247 </span>
             </a>
             </p>
             <p>
@@ -105,10 +105,16 @@
             </a>&nbsp;applies for all files.&nbsp;Under this Open Access license
             anyone&nbsp; may copy, distribute, or reuse the files as long as the authors and the original source are properly cited.
             </p>
+            <p>
+            <strong>Published paper 2020: </strong>
+            <a href="https://humanbrainproject.github.io/hbp-bsp-live-papers/2020/masoli_et_al_2020/masoli_et_al_2020.html " target="_blank">
+                <span class="color_link">https://humanbrainproject.github.io/hbp-bsp-live-papers/2020/masoli_et_al_2020/masoli_et_al_2020.html </span>
+            </a>
+            </p>
         </div>
         <div class="note rounded">
             <h5>Abstract:</h5>
-            The cerebellar granule cells (GrCs) are classically described as a homogeneous neuronal population discharging regularly without adaptation. We show that GrCs in fact generate diverse response patterns to current injection and synaptic activation, ranging from adaptation to acceleration of firing. Adaptation was predicted by parameter optimization in detailed computational models based on available knowledge on GrC ionic channels. The models also predicted that acceleration required additional mechanisms. We found that yet unrecognized TRPM4 currents specifically accounted for firing acceleration and that adapting GrCs outperformed accelerating GrCs in transmitting high-frequency mossy fiber (MF) bursts over a background discharge. This implied that GrC subtypes identified by their electroresponsiveness  corresponded to specific neurotransmitter release probability values. Simulations showed that fine-tuning of pre- and post-synaptic parameters generated effective MF-GrC transmission channels, which could enrich the processing of input spike patterns and enhance spatio-temporal recoding at the cerebellar input stage.    
+            The cerebellar granule cells (GrCs) form an anatomically homogeneous neuronal population which, in its canonical description, discharges regularly without adaptation. We show here that GrCs in fact generate diverse response patterns to current injection and synaptic activation, ranging from adaptation to acceleration of firing. Adaptation was predicted by parameter optimization in detailed GrC computational models based on the available knowledge on GrC ionic channels. The models also predicted that acceleration required the involvement of additional mechanisms. We found that yet unrecognized TRPM4 currents in accelerating GrCs could specifically account for firing acceleration. Moreover, adapting GrCs were better in transmitting high-frequency mossy fiber (MF) bursts over a background discharge than accelerating GrCs. This implied that different electroresponsive patterns corresponded to specific synaptic properties reflecting different neurotransmitter release probability. The correspondence of pre- and post-synaptic properties generated effective MF-GrC transmission channels, which could enrich the processing of input spike patterns and enhance spatio-temporal recoding at the cerebellar input stage.    
         </div>
         <h5>Resources</h5>
         <p>Data and models: Experimental data and models used in the paper are available at the links reported below, grouped into the following categories:

--- a/2020/masoli_et_al_2020b/masoli_et_al_2020b.html
+++ b/2020/masoli_et_al_2020b/masoli_et_al_2020b.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <script type="text/javascript" src="../../static/js/load_ga.js"></script>
+        <title>Masoli et al. 2020</title>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+        <meta name="viewport" content="width = device-width, initial-scale = 1">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+        <link rel="stylesheet" type="text/css" href="../../static/css/live_paper.css">
+        <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
+        <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.3/js/materialize.min.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.6/nv.d3.min.css">
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.5/angular.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.5/angular-resource.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.6/nv.d3.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-nvd3/1.0.9/angular-nvd3.min.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/NeuralEnsemble/neo-viewer@master/js/src/visualizer.js"></script>
+        <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/NeuralEnsemble/neo-viewer@master/js/src/services.js"></script>
+    </head>
+    <body class="container">
+        <br>
+        <div class="box rounded centered">
+            <a href="../../index.html" class="waves-effect waves-light" style="text-align:center; color:black">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <img class="hbp-icon-small" src="../../static/imgs/hbp_diamond_120.png">
+                            </td>
+                            <td>
+                                <span class="title-style subtitle" style="padding-left:5px;">
+                                    The Brain Simulation Platform "Live Papers"
+                                </span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </a>
+            <h5 class="title-style">Cerebellar Golgi cell models predict dendritic processing and mechanisms of synaptic plasticity</h5>
+        </div>
+        <div>
+            <p>
+            <strong>Authors: </strong>Stefano Masoli
+            <sup>1</sup>, Alessandra Ottaviani
+            <sup>1</sup>, Egidio D'Angelo
+            <sup>1,2</sup>
+            </p>
+            <p>
+            <strong>Author information: </strong>
+            <sup>1</sup> Department of Brain and Behavioral Sciences, University of Pavia, Via Forlanini 6, I-27100, Pavia, Italy,
+            <sup>2</sup> Brain Connectivity Center, IRCCS Mondino Foundation, Via Mondino 2, I-27100, Pavia, Italy,
+            </p>
+            <p>
+            <strong>Corresponding author: </strong>Egidio D'Angelo (
+            <em>
+                <a href="mailto:dangelo@unipv.it">dangelo@unipv.it</a>
+            </em> )
+            </p>
+        </div>
+        <div class="rainbow-row">
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+        <div>
+            <p>
+            <strong>Journal: </strong>
+            <a href="https://www.biorxiv.org/" target="_blank">
+                <span class="color_link">Biorxiv</span>
+            </a>
+            </p>
+            <p>
+            <strong>Download Url: </strong>
+            <a href="https://www.biorxiv.org/content/10.1101/2020.05.13.093906v1" target="_blank">
+                <span class="color_link">https://www.biorxiv.org/content/10.1101/2020.05.13.093906v1</span>
+            </a>
+            </p>
+            <p>
+            <strong>Citation: </strong> Stefano Masoli, Alessandra Ottaviani, Egidio D'Angelo. Cerebellar Golgi cell models predict dendritic processing and mechanisms of synaptic plasticity. Biorxiv 2020.
+            </p>
+            <p>
+            <strong>DOI: </strong>
+            <a href="https://10.1101/2020.05.13.093906" target="_blank">
+                <span class="color_link">https://10.1101/2020.05.13.093906</span>
+            </a>
+            </p>
+            <p>
+            <strong>Licence: </strong>the
+            <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">
+                <span class="color_link">Creative Commons Attribution (CC BY) license</span>
+            </a>&nbsp;applies for all files.&nbsp;Under this Open Access license
+            anyone&nbsp; may copy, distribute, or reuse the files as long as the authors and the original source are properly cited.
+            </p>
+        </div>
+        <div class="note rounded">
+            <h5>Abstract:</h5>
+            The Golgi cells are the main inhibitory interneurons of the cerebellar granular layer. Although recent works have highlighted the complexity of their dendritic organization and synaptic inputs, the mechanisms through which these neurons integrate complex input patterns remained unknown. Here we have used 8 detailed morphological reconstructions to develop multicompartmental models of Golgi cells, in which Na, Ca, and K channels were distributed along dendrites, soma, axonal initial segment and axon. The models faithfully reproduced a rich pattern of electrophysiological and pharmacological properties and predicted the operating mechanisms of these neurons. Basal dendrites turned out to be more tightly electrically coupled to the axon initial segment than apical dendrites. During synaptic transmission, parallel fibers caused slow Ca-dependent depolarizations in apical dendrites that boosted the axon initial segment encoder and Na-spike backpropagation into basal dendrites, while inhibitory synapses effectively shunted backpropagating currents. This oriented dendritic processing set up a coincidence detector controlling voltage-dependent NMDA receptor unblock in basal dendrites, which, by regulating local calcium influx, may provide the basis for spike-timing dependent plasticity anticipated by theory.    
+        </div>
+        <h5>Resources</h5>
+        <p>Electrophysiological data available on the Knowledge graph. 
+        One model (more will be added) used in the paper, is available at the links reported below, grouped into the following categories:
+        </p>
+        <ul class="collapsible" data-collapsible="expandable">
+            <li class="active">
+                <div class="collapsible-header amber lighten-5">
+                    <i class="material-icons">settings_input_antenna</i>Morphologies
+                </div>
+                <!-- option: leak_remove -->
+                <div class="collapsible-body ">
+                    <p>The morphology for the dendrites and soma is in .asc format. Modified from neuromorpho.org </p>
+                    <!-- <p>The explanation of how to setup a custom axon, or a specific dendritic sectionlist is available at the following link:</p> -->
+
+                    <div style="margin-left:25px">
+                        <table class="striped">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        Golgi cell morphology 1:
+                                    </td>
+                                    <td>
+                                        <a href="https://object.cscs.ch:443/v1/AUTH_c0a333ecf7c045809321ce9d9ecdfdea/cerebellum_circuits/BlueNaaS_models/live_paper_GoC/pair-140514-C2-1_split_1.asc" class="waves-effect waves-light">
+                                            <i class="material-icons left">archive</i>Download
+                                        </a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <br>
+                    </div>
+                </div>
+            </li>
+            <li>
+                <div class="collapsible-header amber lighten-5">
+                    <i class="material-icons">note_add</i>Cerebellar Golgi cells simulation with BlueNaaS
+                </div>
+                <!-- option: folder_special, archive -->
+                <div class="collapsible-body">
+                    <p><br>Use the BSP Neuron As A Service (NaaS) tool to do in silico experiments with the single cell models shown in Fig. 1C,1D,3A,3B of the paper:
+                    <br>
+                    <span style="margin-left:25px">> Start by clicking on any button below to run a simulation.</span>
+                    <br>
+                    <span style="margin-left:25px">> After entering the NaaS page, click on the "Simulation" tab, adjust the current strength with the appropriate value, and run the simulation by clicking the "Start simulation" button.</span>
+                    <br>
+                    <span style="margin-left:25px">> To correctly run a simulation, the temperature need to be set at 32°, the vinit at -70mV and, to match the paper experiments, and fixed time step at 0.025.  Valid positive current injections are from 0.1 to 1nA. </span>
+                    </p>
+                    <div style="margin-left:25px">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <button class="btn waves-effect waves-light" onclick="window.open('https://blue-naas.humanbrainproject.eu/#/url/cerebellum_circuits/BlueNaaS_models/live_paper_GoC/GoC_morfo1.zip')">Golgi cell Morphology 1.
+                                            <i class="material-icons right">play_arrow</i>
+                                        </button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <br>
+                </div>
+            </li>
+        </ul>
+        <br>
+        <div class="rainbow-row">
+            <div></div> 
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+        <br>
+        <br>
+    </body>
+</html>


### PR DESCRIPTION
Restored the 2019 version with information from the preprint.
Added a link to the 2020 version.